### PR TITLE
Break long filenames in file dropzone

### DIFF
--- a/components/FileDropzone.js
+++ b/components/FileDropzone.js
@@ -67,7 +67,7 @@ export function FileDropzone({handleDrop, disabled, filename}) {
                     place-content: center;
                     border: 5px dashed var(--fcf-very-dark-blue);
                     padding: 24px;
-                    word-break: break-all;
+                    word-break: break-word;
                 }
                 
                 .dropzone-box:active:not(.disabled) p,

--- a/components/FileDropzone.js
+++ b/components/FileDropzone.js
@@ -67,6 +67,7 @@ export function FileDropzone({handleDrop, disabled, filename}) {
                     place-content: center;
                     border: 5px dashed var(--fcf-very-dark-blue);
                     padding: 24px;
+                    word-break: break-all;
                 }
                 
                 .dropzone-box:active:not(.disabled) p,


### PR DESCRIPTION
# Before
<img width="421" alt="image" src="https://user-images.githubusercontent.com/5098748/161234264-74630888-98a1-499c-8007-6eecd5f7f31b.png">

# After
<img width="442" alt="image" src="https://user-images.githubusercontent.com/5098748/161234298-73a5ea83-62c6-4194-abc7-2db05252732b.png">
